### PR TITLE
feat: 부모 목록 조회하는 엔드포인트 추가

### DIFF
--- a/backend/ongi/src/main/java/ongi/family/controller/FamilyController.java
+++ b/backend/ongi/src/main/java/ongi/family/controller/FamilyController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import ongi.family.dto.FamilyCreateRequest;
 import ongi.family.dto.FamilyInfo;
 import ongi.family.dto.FamilyJoinRequest;
+import ongi.family.dto.FamilyParentResponse;
 import ongi.family.service.FamilyService;
 import ongi.security.CustomUserDetails;
 import ongi.user.dto.UserInfo;
@@ -38,6 +39,13 @@ public class FamilyController {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<UserInfo> familyMembers = familyService.getFamilyMembers(userDetails.getUser());
         return ResponseEntity.ok(familyMembers);
+    }
+
+    @GetMapping("/parents")
+    public ResponseEntity<List<FamilyParentResponse>> getFamilyParents(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<FamilyParentResponse> parents = familyService.getFamilyParents(userDetails.getUser());
+        return ResponseEntity.ok(parents);
     }
 
     @PostMapping

--- a/backend/ongi/src/main/java/ongi/family/dto/FamilyParentResponse.java
+++ b/backend/ongi/src/main/java/ongi/family/dto/FamilyParentResponse.java
@@ -1,0 +1,15 @@
+package ongi.family.dto;
+
+import ongi.user.entity.User;
+
+import java.util.UUID;
+
+public record FamilyParentResponse(
+        UUID uuid,
+        String name,
+        String email
+) {
+    public FamilyParentResponse(User user) {
+        this(user.getUuid(), user.getName(), user.getEmail());
+    }
+} 

--- a/backend/ongi/src/main/java/ongi/family/service/FamilyService.java
+++ b/backend/ongi/src/main/java/ongi/family/service/FamilyService.java
@@ -9,6 +9,7 @@ import ongi.exception.EntityNotFoundException;
 import ongi.family.dto.FamilyCreateRequest;
 import ongi.family.dto.FamilyInfo;
 import ongi.family.dto.FamilyJoinRequest;
+import ongi.family.dto.FamilyParentResponse;
 import ongi.family.entity.Family;
 import ongi.family.repository.FamilyRepository;
 import ongi.family.support.FamilyCodeGenerator;
@@ -76,9 +77,30 @@ public class FamilyService {
         Family family = familyRepository.findByMembersContains(user.getUuid())
                 .orElseThrow(() -> new EntityNotFoundException("가족 정보를 찾을 수 없습니다."));
 
-        return family.getMembers().stream()
-                .map(memberId -> new UserInfo(userRepository.findByUuid(memberId)
-                        .orElseThrow(() -> new EntityNotFoundException("가족 멤버 중 탈퇴한 사용자가 있습니다."))))
+        List<User> members = userRepository.findAllById(family.getMembers());
+        
+        if (members.size() != family.getMembers().size()) {
+            throw new EntityNotFoundException("가족 멤버 중 탈퇴한 사용자가 있습니다.");
+        }
+
+        return members.stream()
+                .map(UserInfo::new)
+                .toList();
+    }
+
+    public List<FamilyParentResponse> getFamilyParents(User user) {
+        Family family = familyRepository.findByMembersContains(user.getUuid())
+                .orElseThrow(() -> new EntityNotFoundException("가족 정보를 찾을 수 없습니다."));
+
+        List<User> members = userRepository.findAllById(family.getMembers());
+        
+        if (members.size() != family.getMembers().size()) {
+            throw new EntityNotFoundException("가족 멤버 중 탈퇴한 사용자가 있습니다.");
+        }
+
+        return members.stream()
+                .filter(User::getIsParent)
+                .map(FamilyParentResponse::new)
                 .toList();
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 현재 사용자의 가족 중 부모 목록을 조회할 수 있는 새로운 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 가족 구성원 정보를 일괄적으로 조회하여 일부 구성원이 누락된 경우 오류가 발생하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `/family/parents` endpoint to retrieve parent members using `FamilyParentResponse` DTO.
> 
>   - **Endpoint Addition**:
>     - Adds `getFamilyParents()` endpoint in `FamilyController` to retrieve parent members.
>     - Endpoint URL: `/family/parents`.
>   - **Service Logic**:
>     - Adds `getFamilyParents()` method in `FamilyService` to filter and return parent members.
>     - Throws `EntityNotFoundException` if any family member is not found.
>   - **DTO**:
>     - Adds `FamilyParentResponse` DTO to represent parent member data with `uuid`, `name`, and `email`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Neibce%2FOnGi&utm_source=github&utm_medium=referral)<sup> for ecf6ebe99d0af1338fbefa97cd9f96a6f39951fe. You can [customize](https://app.ellipsis.dev/Neibce/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->