### PR TITLE
fix: StartScreen에서 이메일 넘겨주는 로직 오류 수정

### DIFF
--- a/frontend/ongi/lib/screens/start_screen.dart
+++ b/frontend/ongi/lib/screens/start_screen.dart
@@ -222,12 +222,12 @@ class _EmailScreenState extends State<EmailScreen> {
 
       if (!mounted) return;
 
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('signup_email', email);
+
       if (exists) {
         Navigator.pushNamed(context, '/login');
       } else {
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.setString('signup_email', email);
-        
         if (!mounted) return;
         Navigator.push(
           context,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 이메일을 공유 환경설정에 저장하는 위치를 개선하여, 조건문과 관계없이 한 번만 저장하도록 변경하였습니다.  
  * 중복된 저장 로직을 제거하여 코드가 간결해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->