### PR TITLE
fix: 이미지 부분에 터치 시 버튼 클릭 안되는 문제 해결

### DIFF
--- a/frontend/ongi/lib/screens/health/health_home_screen.dart
+++ b/frontend/ongi/lib/screens/health/health_home_screen.dart
@@ -377,13 +377,15 @@ class _HealthHomeScreenState extends State<HealthHomeScreen> {
                     Positioned(
                       right: 0,
                       top: -20,
-                      child: Container(
-                        height: 150,
-                        clipBehavior: Clip.hardEdge,
-                        decoration: const BoxDecoration(),
-                        child: Image.asset(
-                          'assets/images/parent_exercise_icon.png',
-                          width: 170,
+                      child: IgnorePointer(
+                        child: Container(
+                          height: 150,
+                          clipBehavior: Clip.hardEdge,
+                          decoration: const BoxDecoration(),
+                          child: Image.asset(
+                            'assets/images/parent_exercise_icon.png',
+                            width: 170,
+                          ),
                         ),
                       ),
                     ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 홈 화면의 운동 버튼 스택에서 아이콘 이미지가 터치 이벤트를 받지 않도록 개선되었습니다. 이제 해당 이미지는 시각적으로만 표시되며, 상호작용이 차단됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->