### PR TITLE
feat: 운동 기록 상세 화면 구현 및 운동 기록 화면과 운동 시간 연동

### DIFF
--- a/frontend/ongi/lib/screens/health/exercise_record_detail_screen.dart
+++ b/frontend/ongi/lib/screens/health/exercise_record_detail_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
-import '../../core/app_colors.dart';
+import 'package:ongi/core/app_colors.dart';
+import 'package:ongi/widgets/date_carousel.dart';
+import 'package:ongi/widgets/time_grid.dart';
 
-class ExerciseRecordDetailScreen extends StatelessWidget {
+class ExerciseRecordDetailScreen extends StatefulWidget {
   final DateTime date;
   final int hours;
   final int minutes;
@@ -14,62 +16,106 @@ class ExerciseRecordDetailScreen extends StatelessWidget {
   });
 
   @override
+  State<ExerciseRecordDetailScreen> createState() =>
+      _ExerciseRecordDetailScreenState();
+}
+
+class _ExerciseRecordDetailScreenState
+    extends State<ExerciseRecordDetailScreen> {
+  List<int> selected = [];
+
+  String _calExTime(List<int> selectedCells) {
+    final totalMinutes = selectedCells.length * 10;
+    final hours = totalMinutes ~/ 60;
+    final minutes = totalMinutes % 60;
+
+    String result = '';
+    if (hours > 0) {
+      result += '$hours시간';
+      if (minutes > 0) {
+        result += ' $minutes분';
+      }
+    } else if (minutes > 0) {
+      result += '$minutes분';
+    } else {
+      result = '0분';
+    }
+
+    return result;
+  }
+
+  // Calculate hours and minutes from selected cells
+  Map<String, int> _calculateHoursAndMinutes(List<int> selectedCells) {
+    final totalMinutes = selectedCells.length * 10;
+    final hours = totalMinutes ~/ 60;
+    final minutes = totalMinutes % 60;
+    return {'hours': hours, 'minutes': minutes};
+  }
+
+  // Handle back navigation with exercise time data
+  void _handleBack() {
+    final timeData = _calculateHoursAndMinutes(selected);
+    Navigator.pop(context, timeData);
+  }
+
+  @override
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.of(context).size.width;
     final circleSize = screenWidth * 1.56;
 
-    return Scaffold(
-      backgroundColor: AppColors.ongiLigntgrey,
-      body: SafeArea(
-        child: Stack(
-          clipBehavior: Clip.none,
-          children: [
-            Align(
-              alignment: Alignment.topCenter,
-              child: Transform.translate(
-                offset: Offset(0, -circleSize * 0.76),
-                child: OverflowBox(
-                  maxWidth: double.infinity,
-                  maxHeight: double.infinity,
-                  child: Container(
-                    width: circleSize,
-                    height: circleSize,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: AppColors.ongiOrange,
-                    ),
-                    child: Center(
-                      child: Padding(
-                        padding: EdgeInsets.only(top: circleSize),
-                        child: OverflowBox(
-                          maxHeight: double.infinity,
-                          child: Column(
-                            children: [
-                              const Text(
-                                '오늘 목표 운동 시간,',
-                                style: TextStyle(
-                                  fontSize: 25,
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.w600,
-                                  height: 1,
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (didPop) {
+        if (!didPop) {
+          _handleBack();
+        }
+      },
+      child: Scaffold(
+        backgroundColor: AppColors.ongiLigntgrey,
+        body: SafeArea(
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              Align(
+                alignment: Alignment.topCenter,
+                child: Transform.translate(
+                  offset: Offset(0, -circleSize * 0.76),
+                  child: OverflowBox(
+                    maxWidth: double.infinity,
+                    maxHeight: double.infinity,
+                    child: Container(
+                      width: circleSize,
+                      height: circleSize,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: AppColors.ongiOrange,
+                      ),
+                      child: Center(
+                        child: Padding(
+                          padding: EdgeInsets.only(top: circleSize * 0.62),
+                          child: OverflowBox(
+                            maxHeight: double.infinity,
+                            child: Column(
+                              children: [
+                                const Text(
+                                  '오늘 목표 운동 시간,',
+                                  style: TextStyle(
+                                    fontSize: 25,
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.w600,
+                                    height: 1,
+                                  ),
                                 ),
-                              ),
-                              const Text(
-                                '다 채우셨나요?',
-                                style: TextStyle(
-                                  fontSize: 40,
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.w600,
+                                const Text(
+                                  '다 채우셨나요?',
+                                  style: TextStyle(
+                                    fontSize: 40,
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.w600,
+                                  ),
                                 ),
-                              ),
-                              Container(
-                                margin: const EdgeInsets.symmetric(vertical: 6),
-                                child: Image.asset(
-                                  'assets/images/exercise_record_title_logo.png',
-                                  width: circleSize * 0.3,
-                                ),
-                              ),
-                            ],
+                              ],
+                            ),
                           ),
                         ),
                       ),
@@ -77,26 +123,121 @@ class ExerciseRecordDetailScreen extends StatelessWidget {
                   ),
                 ),
               ),
-            ),
-            Positioned(
-              top: circleSize * 0.5,
-              left: 0,
-              right: 0,
-              child: Center(
+
+              Positioned(
+                top: circleSize * 0.5,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                child: Padding(
+                  padding: const EdgeInsets.only(
+                    left: 15,
+                    right: 15,
+                    bottom: 20,
+                  ),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    child: Stack(
+                      children: [
+                        Positioned(
+                          top: 20,
+                          right: 0,
+                          child: SizedBox(
+                            width: 200,
+                            height: 100,
+                            child: DateCarousel(
+                              initialDate: widget.date,
+                              onDateChanged: (selectedDate) {},
+                            ),
+                          ),
+                        ),
+                        Padding(
+                          padding: EdgeInsets.only(left: 25, top: 75),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              const Text(
+                                '오늘은',
+                                style: TextStyle(
+                                  fontSize: 20,
+                                  color: AppColors.ongiOrange,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              RichText(
+                                text: TextSpan(
+                                  text: '${_calExTime(selected)} ',
+                                  style: TextStyle(
+                                    fontSize: 35,
+                                    color: AppColors.ongiOrange,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                  children: [
+                                    TextSpan(
+                                      text: '운동했어요!',
+                                      style: TextStyle(
+                                        fontSize: 20,
+                                        color: AppColors.ongiOrange,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        Positioned(
+                          top: 160,
+                          left: 7,
+                          right: 7,
+                          bottom: 20,
+                          child: Center(
+                            child: TimeGrid(
+                              initialSelected: selected,
+                              cellColor: Colors.white,
+                              cellSelectedColor: AppColors.ongiOrange,
+                              borderColor: AppColors.ongiOrange,
+                              onValueChanged: (newList) {
+                                setState(() => selected = newList);
+                              },
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
               ),
-            ),
-            // Back button
-            Positioned(
-              top: 16,
-              left: 16,
-              child: IconButton(
-                icon: const Icon(Icons.arrow_back, color: Colors.white),
-                onPressed: () => Navigator.pop(context),
+              Positioned(
+                top: circleSize * 0.23,
+                left: 0,
+                right: 0,
+                child: Center(
+                  child: Container(
+                    margin: const EdgeInsets.symmetric(vertical: 6),
+                    child: Image.asset(
+                      'assets/images/exercise_record_title_logo.png',
+                      width: circleSize * 0.23,
+                    ),
+                  ),
+                ),
               ),
-            ),
-          ],
+              Positioned(
+                top: 16,
+                left: 16,
+                child: IconButton(
+                  icon: const Icon(Icons.arrow_back, color: Colors.white),
+                  onPressed: _handleBack,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
   }
-} 
+}

--- a/frontend/ongi/lib/screens/health/exercise_record_screen.dart
+++ b/frontend/ongi/lib/screens/health/exercise_record_screen.dart
@@ -20,10 +20,21 @@ class _ExerciseRecordScreenState extends State<ExerciseRecordScreen> {
   bool _isSwipeTriggered =
       false; // Prevent button callback when triggered by swipe
 
-  // Get exercise time for a specific date (placeholder: returns 0)
+  // Store exercise times for different dates
+  Map<String, Map<String, int>> exerciseTimes = {};
+
+  // Get exercise time for a specific date
   Map<String, int> getExerciseTime(DateTime date) {
-    // TODO: Replace with real backend call
-    return {'hours': 1, 'minutes': 30};
+    final dateKey = "${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}";
+    return exerciseTimes[dateKey] ?? {'hours': 0, 'minutes': 0};
+  }
+
+  // Save exercise time for a specific date
+  void saveExerciseTime(DateTime date, int hours, int minutes) {
+    final dateKey = "${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}";
+    setState(() {
+      exerciseTimes[dateKey] = {'hours': hours, 'minutes': minutes};
+    });
   }
 
   // Convert page index to date for exercise PageView
@@ -149,8 +160,8 @@ class _ExerciseRecordScreenState extends State<ExerciseRecordScreen> {
                                                   getExerciseTime(date);
 
                                               return GestureDetector(
-                                                onTap: () {
-                                                  Navigator.push(
+                                                onTap: () async {
+                                                  final result = await Navigator.push(
                                                     context,
                                                     MaterialPageRoute(
                                                       builder: (_) =>
@@ -165,6 +176,13 @@ class _ExerciseRecordScreenState extends State<ExerciseRecordScreen> {
                                                           ),
                                                     ),
                                                   );
+                                                  
+                                                  // Handle returned exercise time data
+                                                  if (result != null && result is Map<String, dynamic>) {
+                                                    final returnedHours = result['hours'] as int;
+                                                    final returnedMinutes = result['minutes'] as int;
+                                                    saveExerciseTime(date, returnedHours, returnedMinutes);
+                                                  }
                                                 },
                                                 child: Padding(
                                                   padding:

--- a/frontend/ongi/lib/widgets/time_grid.dart
+++ b/frontend/ongi/lib/widgets/time_grid.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:ongi/core/app_colors.dart';
+
+class TimeGrid extends StatefulWidget {
+  final List<int> initialSelected;
+  final Color cellColor;
+  final Color cellSelectedColor;
+  final Color borderColor;
+  final ValueChanged<List<int>>? onValueChanged;
+
+  const TimeGrid({
+    Key? key,
+    this.initialSelected = const [],
+    this.cellColor = Colors.white,
+    this.cellSelectedColor = AppColors.ongiOrange,
+    this.borderColor = AppColors.ongiOrange,
+    this.onValueChanged,
+  }) : super(key: key);
+
+  @override
+  _TimeGridState createState() => _TimeGridState();
+}
+
+class _TimeGridState extends State<TimeGrid> {
+  late Set<int> _selected;
+  static const int _startHour = 6;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = widget.initialSelected.toSet();
+  }
+
+  @override
+  void didUpdateWidget(covariant TimeGrid old) {
+    super.didUpdateWidget(old);
+    if (!listEquals(old.initialSelected, widget.initialSelected)) {
+      _selected = widget.initialSelected.toSet();
+    }
+  }
+
+  String _formatHour(int h) {
+    final period = h < 12 ? '오전' : '오후';
+    var disp = h % 12;
+    if (disp == 0) disp = 12;
+    return '$period ${disp}시';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hours = List<int>.generate(24, (i) => (_startHour + i) % 24);
+
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          for (var hour in hours)
+            Row(
+              children: [
+                Container(
+                  width: 80,
+                  height: 38,
+                  alignment: Alignment.center,
+                  padding: const EdgeInsets.only(left: 10),
+                  child: Text(
+                    _formatHour(hour),
+                    style: const TextStyle(
+                      color: Colors.grey,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                for (int seg = 0; seg < 6; seg++)
+                  GestureDetector(
+                    onTap: () {
+                      final idx = hour * 6 + seg;
+                      setState(() {
+                        if (_selected.contains(idx))
+                          _selected.remove(idx);
+                        else
+                          _selected.add(idx);
+                        widget.onValueChanged?.call(_selected.toList()..sort());
+                      });
+                    },
+                    child: Container(
+                      margin: const EdgeInsets.symmetric(
+                        horizontal: 1.0,
+                        vertical: 1.0,
+                      ),
+                      width: 40,
+                      height: 30,
+                      decoration: BoxDecoration(
+                        color: _selected.contains(hour * 6 + seg)
+                            ? widget.cellSelectedColor
+                            : widget.cellColor,
+                        border: Border.all(color: widget.borderColor),
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# 구현 요소
1. 운동 기록 상세 화면 구현 완료
2. 운동 기록 화면과 운동 시간 연동 완료

# 추후 해야 할 일
1. 백엔드 운동 기록 관련 작업 완료되면, 날짜별 운동 시간을 DB와 연결하여 저장되게 하기
2. 운동 기록 화면 및 상세 화면에 nav 바 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 운동 기록 상세 화면에서 시간 선택 그리드가 추가되어, 사용자가 운동 시간을 10분 단위로 직접 선택할 수 있습니다.
  * 선택한 운동 시간이 실시간으로 표시되며, 뒤로 가기 시 선택한 시간이 상위 화면에 반영됩니다.
  * 운동 기록 화면에서 각 날짜별로 운동 시간을 저장하고, 상세 화면에서 선택한 시간이 자동으로 업데이트됩니다.
  * 24시간(오전 6시~다음날 6시) 기반의 인터랙티브한 시간 선택 그리드 위젯이 도입되었습니다.

* **개선 사항**
  * 운동 시간 입력 및 표시가 더욱 직관적이고 동적으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->