### PR TITLE
feat: 마음 기록 전면 카메라 사진 등록 기능 추가 (사진 2개 등록 가능하도록)

### DIFF
--- a/backend/ongi/src/main/java/ongi/maum_log/dto/MaumLogPresignedResponseDto.java
+++ b/backend/ongi/src/main/java/ongi/maum_log/dto/MaumLogPresignedResponseDto.java
@@ -1,10 +1,22 @@
 package ongi.maum_log.dto;
 
 public record MaumLogPresignedResponseDto(
-        String presignedUrl,
-        String fileName
+        String frontFileName,
+        String frontPresignedUrl,
+        String backFileName,
+        String backPresignedUrl
 ) {
-    public static MaumLogPresignedResponseDto from(String presignedUrl, String fileName) {
-        return new MaumLogPresignedResponseDto(presignedUrl, fileName);
+    public static MaumLogPresignedResponseDto from(
+            String frontFileName,
+            String frontPresignedUrl,
+            String backFileName,
+            String backPresignedUrl
+    ) {
+        return new MaumLogPresignedResponseDto(
+                frontFileName,
+                frontPresignedUrl,
+                backFileName,
+                backPresignedUrl
+        );
     }
 }

--- a/backend/ongi/src/main/java/ongi/maum_log/dto/MaumLogUploadRequestDto.java
+++ b/backend/ongi/src/main/java/ongi/maum_log/dto/MaumLogUploadRequestDto.java
@@ -5,16 +5,10 @@ import java.util.List;
 import ongi.maum_log.enums.Emotion;
 
 public record MaumLogUploadRequestDto(
-        @NotNull
-        String fileName,
-
-        @NotNull
-        String fileExtension,
-
+        @NotNull String frontFileName,
+        @NotNull String backFileName,
         String location,
-
         String comment,
-
         List<Emotion> emotions
 ) {
 

--- a/backend/ongi/src/main/java/ongi/maum_log/entity/MaumLog.java
+++ b/backend/ongi/src/main/java/ongi/maum_log/entity/MaumLog.java
@@ -27,10 +27,10 @@ public class MaumLog extends BaseEntity {
     private Long id;
 
     @Column(nullable = false, unique = true)
-    private String fileName;
+    private String frontFileName;
 
-    @Column(nullable = false)
-    private String fileExtension;
+    @Column(nullable = false, unique = true)
+    private String backFileName;
 
     private String location;
 

--- a/backend/ongi/src/main/java/ongi/maum_log/repository/MaumLogRepository.java
+++ b/backend/ongi/src/main/java/ongi/maum_log/repository/MaumLogRepository.java
@@ -11,7 +11,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface MaumLogRepository extends JpaRepository<MaumLog, Long> {
 
-    boolean existsByFileName(String fileName);
+    boolean existsByFrontFileName(String fileName);
+    boolean existsByBackFileName(String fileName);
 
     @Query(value = """
             SELECT DATE(created_at) AS date, COUNT(*) AS count

--- a/backend/ongi/src/main/java/ongi/maum_log/service/MaumLogService.java
+++ b/backend/ongi/src/main/java/ongi/maum_log/service/MaumLogService.java
@@ -40,16 +40,19 @@ public class MaumLogService {
 
     @Transactional
     public void createMaumLog(CustomUserDetails userDetails, MaumLogUploadRequestDto request) {
-        if (!s3FileService.objectExists(DIR_NAME, request.fileName())) {
+        if (!s3FileService.objectExists(DIR_NAME, request.frontFileName())
+                || !s3FileService.objectExists(DIR_NAME, request.backFileName())) {
             throw new IllegalArgumentException("S3에 파일 존재하지 않음");
         }
-        if(maumLogRepository.existsByFileName(request.fileName())) {
+
+        if (maumLogRepository.existsByFrontFileName(request.frontFileName())
+                || maumLogRepository.existsByBackFileName(request.backFileName())) {
             throw new EntityAlreadyExistException("이미 업로드된 항목입니다");
         }
 
         MaumLog maumLog = MaumLog.builder()
-                .fileName(request.fileName())
-                .fileExtension(request.fileExtension())
+                .frontFileName(request.frontFileName())
+                .backFileName(request.backFileName())
                 .emotions(request.emotions())
                 .comment(request.comment())
                 .location(request.location())
@@ -62,7 +65,8 @@ public class MaumLogService {
         maumLogRepository.save(maumLog);
     }
 
-    public MaumLogCalendarDto getMaumLogCalendar(CustomUserDetails userDetails, YearMonth yearMonth) {
+    public MaumLogCalendarDto getMaumLogCalendar(CustomUserDetails userDetails,
+            YearMonth yearMonth) {
         Family family = familyRepository.findByMembersContains(userDetails.getUser().getUuid())
                 .orElseThrow(() -> new IllegalArgumentException("가족 정보를 찾을 수 없습니다."));
 
@@ -80,13 +84,21 @@ public class MaumLogService {
             fullResult.put(date, result.getOrDefault(date, 0));
         }
 
-       return MaumLogCalendarDto.from(family.getMembers().size(), fullResult);
+        return MaumLogCalendarDto.from(family.getMembers().size(), fullResult);
     }
 
     public MaumLogPresignedResponseDto getPresignedPutUrl(CustomUserDetails userDetails) {
-        String fileName = UUID.randomUUID().toString();
-        URL presignedUrl = s3FileService.createSignedPutUrl(userDetails.getUser(), DIR_NAME,
-                fileName);
-        return MaumLogPresignedResponseDto.from(presignedUrl.toString(), fileName);
+        String frontFileName = UUID.randomUUID().toString();
+        URL frontPresignedUrl = s3FileService.createSignedPutUrl(userDetails.getUser(), DIR_NAME,
+                frontFileName);
+
+        String backFileName = UUID.randomUUID().toString();
+        URL backPresignedUrl = s3FileService.createSignedPutUrl(userDetails.getUser(), DIR_NAME,
+                backFileName);
+
+        return MaumLogPresignedResponseDto.from(
+                frontFileName, frontPresignedUrl.toString(),
+                backFileName, backPresignedUrl.toString()
+        );
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 마음로그 업로드 시 앞면과 뒷면 파일을 각각 등록할 수 있도록 기능이 확장되었습니다.
  * presigned URL 발급 시 앞면과 뒷면 파일 각각에 대해 파일명과 URL이 제공됩니다.

* **Bug Fixes**
  * 파일명 중복 검사 및 저장 로직이 앞면/뒷면 파일별로 정확하게 동작하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->