### PR TITLE
feat: 마음 일기 캘린더, 상세조회 간 선택 날짜 연결

### DIFF
--- a/frontend/ongi/lib/screens/photo/photo_calendar_screen.dart
+++ b/frontend/ongi/lib/screens/photo/photo_calendar_screen.dart
@@ -267,7 +267,7 @@ class _PhotoCalendarScreenState extends State<PhotoCalendarScreen> {
     if (_currentView == 'photoDate') {
       return Stack(
         children: [
-          const PhotoDateScreen(date:"2025-08-11"),
+          PhotoDateScreen(date: _selectedDate != null ? _formatDateKey(_selectedDate!) : _formatDateKey(DateTime.now())),
           Positioned(
             top: MediaQuery.of(context).padding.top + 15,
             left: 40,

--- a/frontend/ongi/lib/screens/photo/photo_date_screen.dart
+++ b/frontend/ongi/lib/screens/photo/photo_date_screen.dart
@@ -27,6 +27,14 @@ class _PhotoDateScreenState extends State<PhotoDateScreen> {
     _loadMaumLogData();
   }
 
+  @override
+  void didUpdateWidget(PhotoDateScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.date != widget.date) {
+      _loadMaumLogData();
+    }
+  }
+
   Future<void> _loadMaumLogData() async {
     try {
       setState(() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 사진 달력에서 선택한 날짜가 즉시 반영되어 해당 날짜의 콘텐츠가 표시되며, 선택이 없을 경우 자동으로 오늘 날짜가 표시됩니다.
  - 날짜 변경 시 사진 상세 화면의 데이터가 자동으로 새로고침되어 이전 날짜의 정보가 남는 문제를 방지합니다.
  - 전반적으로 날짜 탐색의 일관성과 신뢰성이 향상되어 달력 이동 시 지연 없이 최신 내용을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->