### PR TITLE
style: 약 컨테이너 세부 디자인 수정

### DIFF
--- a/frontend/ongi/lib/screens/health/add_pill_screen.dart
+++ b/frontend/ongi/lib/screens/health/add_pill_screen.dart
@@ -136,7 +136,7 @@ class _AddPillScreenState extends State<AddPillScreen> {
       case '취침 전':
         return 'BEFORE_SLEEP';
       case '상관없음':
-        return 'NONE';
+        return 'ANYTIME';
       default:
         return 'ANYTIME';
     }

--- a/frontend/ongi/lib/screens/health/pill_history_screen.dart
+++ b/frontend/ongi/lib/screens/health/pill_history_screen.dart
@@ -48,6 +48,23 @@ class _PillHistoryScreenState extends State<PillHistoryScreen> {
     return raw;
   }
 
+  String _mapIntakeDetailToKorean(String label) {
+    switch (label) {
+      case 'BEFORE_MEAL_30MIN':
+        return '식전 30분';
+      case 'AFTER_MEAL_30MIN':
+        return '식후 30분 이내';
+      case 'AFTER_MEAL_60MIN':
+        return '식후 1시간';
+      case 'BEFORE_SLEEP':
+        return '취침 전';
+      case 'ANYTIME':
+        return '상관없음';
+      default:
+        return '';
+    }
+  }
+
   Future<void> _addRecord({
     required String pillId,
     required String intakeTime,
@@ -180,7 +197,9 @@ class _PillHistoryScreenState extends State<PillHistoryScreen> {
                                   MaterialPageRoute(
                                     builder: (context) => const AddPillScreen(),
                                   ),
-                                );
+                                ).then((_) {
+                                  _fetchTodaySchedule();
+                                });
                               },
                               child: Container(
                                 margin: const EdgeInsets.symmetric(
@@ -221,8 +240,10 @@ class _PillHistoryScreenState extends State<PillHistoryScreen> {
                           final String pillId = idRaw?.toString() ?? '';
                           final String pillName = (pill['name'] ?? '약물')
                               .toString();
-                          final String intakeDetail =
-                              (pill['intakeDetail'] ?? '').toString();
+                          final String intakeDetail = _mapIntakeDetailToKorean(
+                            pill['intakeDetail'],
+                          ).toString();
+                          // (pill['intakeDetail'] ?? '').toString();
                           final List<dynamic> timesDyn =
                               pill['intakeTimes'] as List<dynamic>? ??
                               <dynamic>[];
@@ -303,8 +324,8 @@ class _PillHistoryScreenState extends State<PillHistoryScreen> {
                                             child: Container(
                                               padding:
                                                   const EdgeInsets.symmetric(
-                                                    horizontal: 16,
-                                                    vertical: 10,
+                                                    horizontal: 27,
+                                                    vertical: 6,
                                                   ),
                                               decoration: BoxDecoration(
                                                 color: taken
@@ -322,21 +343,10 @@ class _PillHistoryScreenState extends State<PillHistoryScreen> {
                                                       color: taken
                                                           ? Colors.black
                                                           : Colors.white,
-                                                      fontSize: 14,
+                                                      fontSize: 11,
                                                       fontWeight:
-                                                          FontWeight.w700,
+                                                          FontWeight.w600,
                                                     ),
-                                                  ),
-                                                  const SizedBox(width: 8),
-                                                  Icon(
-                                                    taken
-                                                        ? Icons.check
-                                                        : Icons
-                                                              .medication_outlined,
-                                                    size: 18,
-                                                    color: taken
-                                                        ? Colors.black
-                                                        : Colors.white,
                                                   ),
                                                 ],
                                               ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 복약 상세가 한국어 라벨로 표시됩니다.
  - 약 추가 후 돌아오면 오늘 일정이 자동으로 새로고침됩니다.
- Style
  - 알약 시간 버튼의 여백(가로 27/세로 6)과 폰트(크기 11, 굵기 w600)로 조정되었습니다.
  - 시간별 복용 상태 아이콘과 여백이 제거되어 카드가 더 간결해졌습니다.
- Bug Fixes
  - ‘상관없음’ 선택 시 서버 전송 값이 일관되게 처리되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->