### PR TITLE
fix: 리워드 LineChart 값 변경 및 마음기록 앨범 daycircle 투명도 변경

### DIFF
--- a/frontend/ongi/lib/screens/photo/photo_calendar_screen.dart
+++ b/frontend/ongi/lib/screens/photo/photo_calendar_screen.dart
@@ -267,7 +267,11 @@ class _PhotoCalendarScreenState extends State<PhotoCalendarScreen> {
     if (_currentView == 'photoDate') {
       return Stack(
         children: [
-          PhotoDateScreen(date: _selectedDate != null ? _formatDateKey(_selectedDate!) : _formatDateKey(DateTime.now())),
+          PhotoDateScreen(
+            date: _selectedDate != null
+                ? _formatDateKey(_selectedDate!)
+                : _formatDateKey(DateTime.now()),
+          ),
           Positioned(
             top: MediaQuery.of(context).padding.top + 15,
             left: 40,
@@ -322,9 +326,8 @@ class _PhotoCalendarScreenState extends State<PhotoCalendarScreen> {
   }
 
   List<Color> _buildCircleColorsForCount(int count) {
-    // final Color orange = AppColors.ongiOrange.withValues(alpha: 0.9);
     final Color orange = AppColors.ongiOrange;
-    final Color grey = AppColors.ongiGrey;
+    final Color grey = AppColors.ongiGrey.withValues(alpha: 0.9);
 
     if (count >= 4) {
       return [orange, orange, orange, orange];

--- a/frontend/ongi/lib/screens/reward_screen.dart
+++ b/frontend/ongi/lib/screens/reward_screen.dart
@@ -365,8 +365,12 @@ class _RewardScreenState extends State<RewardScreen> {
                                           ),
                                         ),
                                         const SizedBox(height: 30),
-                                        CustomLineChart(current: availableTempValue != null
-                                            ? availableTempValue! + 36.5 : 0, max: 300),
+                                        CustomLineChart(
+                                          current: availableTempValue != null
+                                              ? availableTempValue!
+                                              : 0,
+                                          max: 300,
+                                        ),
                                       ],
                                     ),
                                   ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 보상 화면 차트에서 불필요한 오프셋을 제거해 실제 가용 값이 정확히 표시되도록 개선했으며 최대값 300을 명시했습니다.
- Style
  - 사진 캘린더 화면의 원형 색상 중 회색의 불투명도를 90%로 조정해 시인성을 개선했습니다.
  - 일부 화면의 컴포넌트 호출부를 다중 행으로 정리해 코드 가독성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->