### PR TITLE
fix: 메인 화면 도넛 안 온도 및 리워드 화면 온도 기본값만 들어가는 에러 해결

### DIFF
--- a/frontend/ongi/lib/screens/home/home_donutCapsule.dart
+++ b/frontend/ongi/lib/screens/home/home_donutCapsule.dart
@@ -54,17 +54,16 @@ class _HomeCapsuleSectionState extends State<HomeCapsuleSection> {
         familyCode,
         token: token,
       );
-      final today = DateTime.now();
-      final todayStr =
-          '${today.year.toString().padLeft(4, '0')}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
-      final match = dailyTemps.firstWhere(
-        (e) => e['date'] == todayStr,
-        orElse: () => <String, dynamic>{},
-      );
+      double latestTotalTemperature;
+      if (dailyTemps.isEmpty) {
+        latestTotalTemperature = 36.5;
+      } else {
+        final lastEntry = dailyTemps.last;
+        latestTotalTemperature =
+            ((lastEntry['totalTemperature'] as num?)?.toDouble()) ?? 36.5;
+      }
       setState(() {
-        todayTemperature = match.isNotEmpty
-            ? (match['totalTemperature'] ?? 36.5)
-            : 36.5;
+        todayTemperature = latestTotalTemperature;
         isLoading = false;
       });
     } catch (e) {

--- a/frontend/ongi/lib/screens/photo/photo_calendar_screen.dart
+++ b/frontend/ongi/lib/screens/photo/photo_calendar_screen.dart
@@ -191,6 +191,9 @@ class _PhotoCalendarScreenState extends State<PhotoCalendarScreen> {
               firstDay: DateTime.utc(2024, 1, 1),
               lastDay: DateTime.utc(2030, 1, 1),
               focusedDay: _focusedDay,
+              // 달력 내부에서는 가로 스와이프(월 전환)만 허용하고,
+              // 세로 드래그는 부모 스크롤뷰로 전달되도록 제한
+              availableGestures: AvailableGestures.horizontalSwipe,
               rowHeight: 90,
               headerStyle: const HeaderStyle(
                 formatButtonVisible: false,

--- a/frontend/ongi/lib/screens/reward_screen.dart
+++ b/frontend/ongi/lib/screens/reward_screen.dart
@@ -79,22 +79,16 @@ class _RewardScreenState extends State<RewardScreen> {
       );
 
       const baseline = 36.5; // 기준 온도
-      final today = DateTime.now();
-      final todayStr =
-          '${today.year.toString().padLeft(4, '0')}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
-
-      final match = dailyTemps.firstWhere(
-        (e) => e['date'] == todayStr,
-        orElse: () => <String, dynamic>{},
-      );
-
-      double value;
-      if (match.isEmpty) {
-        value = 0.0;
+      double latestTotalTemperature;
+      if (dailyTemps.isEmpty) {
+        latestTotalTemperature = 36.5;
       } else {
-        final raw = (match['totalTemperature'] as num?)?.toDouble();
-        value = raw == null ? 0.0 : (raw - baseline);
+        final lastEntry = dailyTemps.last;
+        latestTotalTemperature =
+            ((lastEntry['totalTemperature'] as num?)?.toDouble()) ?? 36.5;
       }
+
+      final value = latestTotalTemperature - baseline;
 
       setState(() {
         // 음수 방지 -> 음수 온도이면 0.0으로 뜸


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 캘린더 화면에서 가로 스와이프만 허용하고, 세로 드래그는 상위 스크롤로 전달해 스크롤 충돌을 방지했습니다.

* 버그 수정
  * 홈/보상 화면의 “오늘 온도”가 날짜 일치 실패 시 비어 보이던 문제를 개선해, 최신 측정값을 기준으로 안정적으로 표시합니다.
  * 일일 데이터가 없는 경우 기본값 36.5를 사용해 오류 없이 표시합니다.
  * 보상 화면의 가용 온도 계산을 최신 온도 기준으로 정정하고 음수 값이 표시되지 않도록 보정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->