### PR TITLE
fix: timezone 한국으로 변경

### DIFF
--- a/backend/ongi/src/main/java/ongi/OngiApplication.java
+++ b/backend/ongi/src/main/java/ongi/OngiApplication.java
@@ -1,5 +1,6 @@
 package ongi;
 
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -11,6 +12,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class OngiApplication {
 
     public static void main(String[] args) {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
         SpringApplication.run(OngiApplication.class, args);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 애플리케이션 기본 시간대를 Asia/Seoul(KST)로 설정했습니다. 서버 시작 시 자동 적용되어 모든 날짜·시간 표시, 일정 처리, 알림 및 로그 타임스탬프가 한국 표준시 기준으로 일관되게 표시됩니다. 사용자는 지역 시간대 혼동 없이 정확한 시간을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->