### PR TITLE
fix: 마음 기록 하루 한 번 기록 제한 구현 | 팝업 화면 크기 수정 | 마음 기록 입력 화면 위치 수정 | 기본 스플래시 화면 제거

### DIFF
--- a/frontend/ongi/android/app/src/main/res/drawable/launch_background.xml
+++ b/frontend/ongi/android/app/src/main/res/drawable/launch_background.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <bitmap android:gravity="fill" android:src="@drawable/background"/>
-    </item>
-    <item>
-        <bitmap android:gravity="center" android:src="@drawable/splash"/>
-    </item>
-</layer-list>

--- a/frontend/ongi/ios/Podfile.lock
+++ b/frontend/ongi/ios/Podfile.lock
@@ -34,8 +34,11 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
   - Flutter (1.0.0)
-  - flutter_native_splash (2.4.3):
+  - geocoding_ios (1.0.5):
     - Flutter
+  - geolocator_apple (1.2.0):
+    - Flutter
+    - FlutterMacOS
   - GoogleDataTransport (10.1.0):
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
@@ -68,6 +71,8 @@ PODS:
     - nanopb/encode (= 3.30910.0)
   - nanopb/decode (3.30910.0)
   - nanopb/encode (3.30910.0)
+  - package_info_plus (0.4.5):
+    - Flutter
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -81,7 +86,9 @@ DEPENDENCIES:
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - Flutter (from `Flutter`)
-  - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
+  - geocoding_ios (from `.symlinks/plugins/geocoding_ios/ios`)
+  - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
+  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
 
@@ -106,31 +113,37 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_messaging/ios"
   Flutter:
     :path: Flutter
-  flutter_native_splash:
-    :path: ".symlinks/plugins/flutter_native_splash/ios"
+  geocoding_ios:
+    :path: ".symlinks/plugins/geocoding_ios/ios"
+  geolocator_apple:
+    :path: ".symlinks/plugins/geolocator_apple/darwin"
+  package_info_plus:
+    :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
 
 SPEC CHECKSUMS:
-  camera_avfoundation: adb0207d868b2d873e895371d88448399ab78d87
+  camera_avfoundation: be3be85408cd4126f250386828e9b1dfa40ab436
   Firebase: d99ac19b909cd2c548339c2241ecd0d1599ab02e
-  firebase_core: 99a37263b3c27536063a7b601d9e2a49400a433c
-  firebase_messaging: bf6697c61f31c7cc0f654131212ff04c0115c2c7
+  firebase_core: 995454a784ff288be5689b796deb9e9fa3601818
+  firebase_messaging: f4a41dd102ac18b840eba3f39d67e77922d3f707
   FirebaseCore: efb3893e5b94f32b86e331e3bd6dadf18b66568e
   FirebaseCoreInternal: 9afa45b1159304c963da48addb78275ef701c6b4
   FirebaseInstallations: 317270fec08a5d418fdbc8429282238cab3ac843
   FirebaseMessaging: 3b26e2cee503815e01c3701236b020aa9b576f09
-  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_native_splash: df59bb2e1421aa0282cb2e95618af4dcb0c56c29
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  geocoding_ios: 33776c9ebb98d037b5e025bb0e7537f6dd19646e
+  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
 
-PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+PODFILE CHECKSUM: 4305caec6b40dde0ae97be1573c53de1882a07e5
 
 COCOAPODS: 1.16.2

--- a/frontend/ongi/lib/screens/bottom_nav.dart
+++ b/frontend/ongi/lib/screens/bottom_nav.dart
@@ -4,9 +4,10 @@ import 'package:ongi/screens/add_record_screen.dart';
 import 'package:ongi/screens/home/home_screen.dart';
 import 'package:ongi/screens/health/health_home_screen.dart';
 import 'package:ongi/screens/photo/photo_calendar_screen.dart';
-import 'package:ongi/screens/photo/photo_date_screen.dart';
 import 'package:ongi/screens/mypage/mypage_screen.dart';
 import 'package:ongi/core/app_colors.dart';
+import 'package:ongi/services/maum_log_service.dart';
+import 'package:intl/intl.dart';
 
 class BottomNavScreen extends StatefulWidget {
   final int initialIndex;
@@ -36,6 +37,67 @@ class _BottomNavScreenState extends State<BottomNavScreen> {
     setState(() {
       _currentIndex = index;
     });
+  }
+
+  Future<void> _onAddRecordTapped() async {
+    try {
+      final today = DateFormat('yyyy-MM-dd').format(DateTime.now());
+
+      final maumLogResponse = await MaumLogService.getMaumLog(today);
+
+      if (maumLogResponse.hasUploadedOwn) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '오늘의 마음 기록 완료!',
+                    style: TextStyle(
+                      color: AppColors.ongiOrange,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  const Text(
+                    '같은 날에는 한 번만 기록할 수 있어요.',
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w400,
+                      color: Colors.black45,
+                    ),
+                  ),
+                ],
+              ),
+              backgroundColor: Colors.white,
+              behavior: SnackBarBehavior.floating,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(20),
+              ),
+              duration: const Duration(seconds: 2),
+            ),
+          );
+        }
+      } else {
+        if (mounted) {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) => const AddRecordScreen()),
+          );
+        }
+      }
+    } catch (e) {
+      print('마음로그 확인 중 에러: $e');
+      if (mounted) {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) => const AddRecordScreen()),
+        );
+      }
+    }
   }
 
   @override
@@ -83,14 +145,7 @@ class _BottomNavScreenState extends State<BottomNavScreen> {
             '건강 기록',
           ),
           GestureDetector(
-            onTap: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const AddRecordScreen(),
-                ),
-              );
-            },
+            onTap: () => _onAddRecordTapped(),
             child: Container(
               width: 56,
               height: 56,

--- a/frontend/ongi/lib/screens/photo/check_record_screen.dart
+++ b/frontend/ongi/lib/screens/photo/check_record_screen.dart
@@ -7,17 +7,25 @@ import 'package:geolocator/geolocator.dart';
 import 'package:geocoding/geocoding.dart';
 import 'package:ongi/screens/photo/detail_record_screen.dart';
 
+import '../home/home_screen.dart';
+
 class CheckRecordScreen extends StatefulWidget {
   final String backImagePath;
   final String? frontImagePath;
   final String? address;
-  const CheckRecordScreen({super.key, required this.backImagePath, this.frontImagePath, this.address});
+  const CheckRecordScreen({
+    super.key,
+    required this.backImagePath,
+    this.frontImagePath,
+    this.address,
+  });
 
   @override
   State<CheckRecordScreen> createState() => CheckRecordScreenState();
 }
 
-class CheckRecordScreenState extends State<CheckRecordScreen> with TickerProviderStateMixin {
+class CheckRecordScreenState extends State<CheckRecordScreen>
+    with TickerProviderStateMixin {
   late CameraController controller;
   List<CameraDescription>? cameras;
   bool isInitialized = false;
@@ -115,29 +123,63 @@ class CheckRecordScreenState extends State<CheckRecordScreen> with TickerProvide
   }
 
   Future<void> _fetchLocation() async {
-    setState(() { _isLocating = true; });
+    setState(() {
+      _isLocating = true;
+    });
     try {
       LocationPermission permission = await Geolocator.checkPermission();
       if (permission == LocationPermission.denied) {
         permission = await Geolocator.requestPermission();
       }
-      if (permission == LocationPermission.deniedForever || permission == LocationPermission.denied) {
-        setState(() { _address = '위치 권한이 필요합니다.'; _isLocating = false; });
+      if (permission == LocationPermission.deniedForever ||
+          permission == LocationPermission.denied) {
+        setState(() {
+          _address = '위치 권한이 필요합니다.';
+          _isLocating = false;
+        });
         return;
       }
-      Position pos = await Geolocator.getCurrentPosition(desiredAccuracy: LocationAccuracy.high);
-      List<Placemark> placemarks = await placemarkFromCoordinates(pos.latitude, pos.longitude);
+      Position pos = await Geolocator.getCurrentPosition(
+        desiredAccuracy: LocationAccuracy.high,
+      );
+      List<Placemark> placemarks = await placemarkFromCoordinates(
+        pos.latitude,
+        pos.longitude,
+      );
       if (placemarks.isNotEmpty) {
         final p = placemarks.first;
         setState(() {
-          _address = '${p.administrativeArea ?? ''} ${p.locality ?? ''} ${p.subLocality ?? ''}'.trim();
+          List<String> addressParts = [];
+          
+          if (p.administrativeArea != null && p.administrativeArea!.isNotEmpty) {
+            addressParts.add(p.administrativeArea!);
+          }
+          
+          // locality가 administrativeArea와 다를 때만 추가
+          if (p.locality != null && 
+              p.locality!.isNotEmpty && 
+              p.locality != p.administrativeArea) {
+            addressParts.add(p.locality!);
+          }
+        
+          if (p.subLocality != null && p.subLocality!.isNotEmpty) {
+            addressParts.add(p.subLocality!);
+          }
+          
+          _address = addressParts.join(' ').trim();
           _isLocating = false;
         });
       } else {
-        setState(() { _address = '주소를 찾을 수 없습니다.'; _isLocating = false; });
+        setState(() {
+          _address = '주소를 찾을 수 없습니다.';
+          _isLocating = false;
+        });
       }
     } catch (e) {
-      setState(() { _address = '위치 정보를 불러올 수 없습니다.'; _isLocating = false; });
+      setState(() {
+        _address = '위치 정보를 불러올 수 없습니다.';
+        _isLocating = false;
+      });
     }
   }
 
@@ -263,7 +305,9 @@ class CheckRecordScreenState extends State<CheckRecordScreen> with TickerProvide
                                 alignment: Alignment.bottomCenter,
                                 child: Padding(
                                   padding: EdgeInsets.only(bottom: 12),
-                                  child: CircularProgressIndicator(color: AppColors.ongiOrange),
+                                  child: CircularProgressIndicator(
+                                    color: AppColors.ongiOrange,
+                                  ),
                                 ),
                               )
                             else if (widget.address != null)
@@ -272,7 +316,10 @@ class CheckRecordScreenState extends State<CheckRecordScreen> with TickerProvide
                                 child: Padding(
                                   padding: const EdgeInsets.only(bottom: 12),
                                   child: Container(
-                                    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 14,
+                                      vertical: 6,
+                                    ),
                                     decoration: BoxDecoration(
                                       color: Colors.white,
                                       borderRadius: BorderRadius.circular(20),
@@ -287,7 +334,11 @@ class CheckRecordScreenState extends State<CheckRecordScreen> with TickerProvide
                                     child: Row(
                                       mainAxisSize: MainAxisSize.min,
                                       children: [
-                                        Icon(Icons.place, color: AppColors.ongiOrange, size: 18),
+                                        Icon(
+                                          Icons.place,
+                                          color: AppColors.ongiOrange,
+                                          size: 18,
+                                        ),
                                         const SizedBox(width: 4),
                                         Text(
                                           widget.address!,
@@ -318,7 +369,7 @@ class CheckRecordScreenState extends State<CheckRecordScreen> with TickerProvide
                       style: ElevatedButton.styleFrom(
                         backgroundColor: AppColors.ongiOrange,
                         foregroundColor: Colors.white,
-                        padding: const EdgeInsets.symmetric(vertical: 18),
+                        padding: const EdgeInsets.symmetric(vertical: 10),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(16),
                         ),
@@ -339,16 +390,14 @@ class CheckRecordScreenState extends State<CheckRecordScreen> with TickerProvide
                       child: const Text(
                         '등록하기',
                         style: TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.w700,
+                          fontSize: 32,
+                          fontWeight: FontWeight.w400,
                           fontFamily: 'Pretendard',
                         ),
                       ),
                     ),
                   ),
                 ),
-
-
                 const Spacer(),
               ],
             ),
@@ -362,7 +411,10 @@ class CheckRecordScreenState extends State<CheckRecordScreen> with TickerProvide
                 width: 28,
               ),
               onPressed: () {
-                Navigator.of(context).pop();
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => HomeScreen()),
+                );
               },
               iconSize: 36,
             ),

--- a/frontend/ongi/lib/screens/photo/detail_record_screen.dart
+++ b/frontend/ongi/lib/screens/photo/detail_record_screen.dart
@@ -13,14 +13,21 @@ class DetailRecordScreen extends StatefulWidget {
   final String? frontImagePath;
   final String? address;
   final DateTime? date;
-  const DetailRecordScreen({super.key, required this.backImagePath, this.frontImagePath, this.address, this.date});
+  const DetailRecordScreen({
+    super.key,
+    required this.backImagePath,
+    this.frontImagePath,
+    this.address,
+    this.date,
+  });
 
   @override
   State<DetailRecordScreen> createState() => _DetailRecordScreenState();
 }
 
 class _DetailRecordScreenState extends State<DetailRecordScreen> {
-  static const String _emotionApiBaseUrl = 'https://ongi-1049536928483.asia-northeast3.run.app';
+  static const String _emotionApiBaseUrl =
+      'https://ongi-1049536928483.asia-northeast3.run.app';
   late Future<List<Emotion>> _emotionsFuture;
   final Set<String> _selectedEmotionCodes = {}; // description 대신 code를 저장
   final TextEditingController _commentController = TextEditingController();
@@ -45,24 +52,25 @@ class _DetailRecordScreenState extends State<DetailRecordScreen> {
     try {
       // 오늘 날짜 형식으로
       final today = widget.date ?? DateTime.now();
-      final todayStr = '${today.year}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
-      
+      final todayStr =
+          '${today.year}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
+
       // 현재 사용자 정보 가져오기
       final userInfo = await PrefsManager.getUserInfo();
       final currentUserName = userInfo['name'] ?? '';
-      
+
       // 가족들의 마음 기록 상태 확인
       final maumLogResponse = await MaumLogService.getMaumLog(todayStr);
-      
+
       if (!mounted) return;
-      
+
       // 현재 사용자 제외한 다른 가족이 사진을 업로드했는지 확인
-      final familyPhotos = maumLogResponse.maumLogDtos.where(
-        (log) => log.uploader != currentUserName
-      ).toList();
-      
+      final familyPhotos = maumLogResponse.maumLogDtos
+          .where((log) => log.uploader != currentUserName)
+          .toList();
+
       final hasFamilyPhotos = familyPhotos.isNotEmpty;
-      
+
       if (hasFamilyPhotos) {
         // 가족들이 사진을 올렸으면 photo_update_popup 보여주기
         await _showPhotoUpdatePopup();
@@ -70,7 +78,7 @@ class _DetailRecordScreenState extends State<DetailRecordScreen> {
         // 가족들이 사진을 올리지 않았으면 photo_remind_popup 보여주기
         await _showPhotoRemindPopup();
       }
-      
+
       // 팝업이 닫힌 후 화면 종료
       if (mounted) {
         Navigator.of(context).pop();
@@ -79,9 +87,9 @@ class _DetailRecordScreenState extends State<DetailRecordScreen> {
       print('가족 사진 상태 확인 중 오류: $e');
       // 오류 발생 시 기본 완료 메시지 표시
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('기록이 저장되었습니다!')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('기록이 저장되었습니다!')));
         Navigator.of(context).pop();
       }
     }
@@ -127,17 +135,26 @@ class _DetailRecordScreenState extends State<DetailRecordScreen> {
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
                       IconButton(
-                        icon: const Icon(Icons.arrow_back_ios_new_rounded, color: Colors.black87),
+                        icon: const Icon(
+                          Icons.arrow_back_ios_new_rounded,
+                          color: Colors.black87,
+                        ),
                         onPressed: () => Navigator.of(context).pop(),
                       ),
                       Row(
                         children: [
                           IconButton(
-                            icon: const Icon(Icons.share_outlined, color: Colors.black54),
+                            icon: const Icon(
+                              Icons.share_outlined,
+                              color: Colors.black54,
+                            ),
                             onPressed: () {},
                           ),
                           IconButton(
-                            icon: const Icon(Icons.more_vert, color: Colors.black54),
+                            icon: const Icon(
+                              Icons.more_vert,
+                              color: Colors.black54,
+                            ),
                             onPressed: () {},
                           ),
                         ],
@@ -149,7 +166,10 @@ class _DetailRecordScreenState extends State<DetailRecordScreen> {
                 // 날짜 오버레이
                 Container(
                   margin: const EdgeInsets.only(top: 0, bottom: 12),
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 5,
+                  ),
                   decoration: BoxDecoration(
                     color: AppColors.ongiOrange,
                     borderRadius: BorderRadius.circular(32),
@@ -210,7 +230,10 @@ class _DetailRecordScreenState extends State<DetailRecordScreen> {
                                 child: Padding(
                                   padding: const EdgeInsets.only(bottom: 12),
                                   child: Container(
-                                    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 14,
+                                      vertical: 6,
+                                    ),
                                     decoration: BoxDecoration(
                                       color: Colors.white,
                                       borderRadius: BorderRadius.circular(20),
@@ -225,7 +248,11 @@ class _DetailRecordScreenState extends State<DetailRecordScreen> {
                                     child: Row(
                                       mainAxisSize: MainAxisSize.min,
                                       children: [
-                                        Icon(Icons.place, color: AppColors.ongiOrange, size: 18),
+                                        Icon(
+                                          Icons.place,
+                                          color: AppColors.ongiOrange,
+                                          size: 18,
+                                        ),
                                         const SizedBox(width: 4),
                                         Text(
                                           widget.address!,
@@ -267,18 +294,26 @@ class _DetailRecordScreenState extends State<DetailRecordScreen> {
                       FutureBuilder<List<Emotion>>(
                         future: _emotionsFuture,
                         builder: (context, snapshot) {
-                          if (snapshot.connectionState == ConnectionState.waiting) {
-                            return const Center(child: CircularProgressIndicator());
+                          if (snapshot.connectionState ==
+                              ConnectionState.waiting) {
+                            return const Center(
+                              child: CircularProgressIndicator(),
+                            );
                           }
                           if (snapshot.hasError) {
-                            return Text('감정 불러오기 실패: ${snapshot.error}', style: TextStyle(color: Colors.red));
+                            return Text(
+                              '감정 불러오기 실패: ${snapshot.error}',
+                              style: TextStyle(color: Colors.red),
+                            );
                           }
                           final emotions = snapshot.data ?? [];
                           return Wrap(
                             spacing: 8,
                             runSpacing: 8,
                             children: emotions.map((e) {
-                              final selected = _selectedEmotionCodes.contains(e.code);
+                              final selected = _selectedEmotionCodes.contains(
+                                e.code,
+                              );
                               return GestureDetector(
                                 onTap: () {
                                   setState(() {
@@ -290,9 +325,14 @@ class _DetailRecordScreenState extends State<DetailRecordScreen> {
                                   });
                                 },
                                 child: Container(
-                                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 14,
+                                    vertical: 8,
+                                  ),
                                   decoration: BoxDecoration(
-                                    color: selected ? AppColors.ongiOrange : AppColors.ongiGrey,
+                                    color: selected
+                                        ? AppColors.ongiOrange
+                                        : AppColors.ongiGrey,
                                     borderRadius: BorderRadius.circular(18),
                                   ),
                                   child: Text(
@@ -322,12 +362,17 @@ class _DetailRecordScreenState extends State<DetailRecordScreen> {
                     children: [
                       CircleAvatar(
                         radius: 22,
-                        backgroundImage: AssetImage('assets/images/users/elderly_woman.png'),
+                        backgroundImage: AssetImage(
+                          'assets/images/users/elderly_woman.png',
+                        ),
                       ),
                       const SizedBox(width: 10),
                       Expanded(
                         child: Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 10,
+                          ),
                           decoration: BoxDecoration(
                             color: Colors.white,
                             borderRadius: BorderRadius.circular(18),
@@ -353,11 +398,12 @@ class _DetailRecordScreenState extends State<DetailRecordScreen> {
                   padding: const EdgeInsets.symmetric(horizontal: 18),
                   child: SizedBox(
                     width: double.infinity,
-                    height: 56,
+                    height: 65,
                     child: ElevatedButton(
                       style: ElevatedButton.styleFrom(
                         backgroundColor: AppColors.ongiOrange,
                         foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 10),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(16),
                         ),
@@ -369,40 +415,51 @@ class _DetailRecordScreenState extends State<DetailRecordScreen> {
                       ),
                       onPressed: () async {
                         try {
-                          final selectedEmotionCodes = _selectedEmotionCodes.toList();
+                          final selectedEmotionCodes = _selectedEmotionCodes
+                              .toList();
                           final comment = _commentController.text.trim();
-                          final accessToken = await PrefsManager.getAccessToken();
-                          
+                          final accessToken =
+                              await PrefsManager.getAccessToken();
+
                           if (accessToken == null) {
                             throw Exception('로그인이 필요합니다. 다시 로그인해주세요.');
                           }
-                          
+
                           print('🔐저장된 토큰: $accessToken');
-                          
+
                           // 사용자 UUID 가져오기
                           final userUuid = await PrefsManager.getUuid();
                           if (userUuid == null) {
                             throw Exception('사용자 정보를 찾을 수 없습니다. 다시 로그인해주세요.');
                           }
-                          
-                          final service = MaumlogService(baseUrl: _emotionApiBaseUrl);
-                          
+
+                          final service = MaumlogService(
+                            baseUrl: _emotionApiBaseUrl,
+                          );
+
                           final presignedData = await service.getPresignedUrls(
                             accessToken: accessToken,
                           );
-                          
-                          final frontFileName = presignedData['frontFileName'] as String;
-                          final frontPresignedUrl = presignedData['frontPresignedUrl'] as String;
-                          final backFileName = presignedData['backFileName'] as String;
-                          final backPresignedUrl = presignedData['backPresignedUrl'] as String;
-                          
+
+                          final frontFileName =
+                              presignedData['frontFileName'] as String;
+                          final frontPresignedUrl =
+                              presignedData['frontPresignedUrl'] as String;
+                          final backFileName =
+                              presignedData['backFileName'] as String;
+                          final backPresignedUrl =
+                              presignedData['backPresignedUrl'] as String;
+
                           await service.uploadFileToS3(
                             presignedUrl: backPresignedUrl,
                             file: File(widget.backImagePath),
                             uploaderUuid: userUuid,
                           );
-                          
-                          final actualFrontFileName = widget.frontImagePath != null ? frontFileName : backFileName;
+
+                          final actualFrontFileName =
+                              widget.frontImagePath != null
+                              ? frontFileName
+                              : backFileName;
                           if (widget.frontImagePath != null) {
                             await service.uploadFileToS3(
                               presignedUrl: frontPresignedUrl,
@@ -410,7 +467,7 @@ class _DetailRecordScreenState extends State<DetailRecordScreen> {
                               uploaderUuid: userUuid,
                             );
                           }
-                          
+
                           await service.uploadMaumLog(
                             frontFileName: actualFrontFileName,
                             backFileName: backFileName,
@@ -421,16 +478,35 @@ class _DetailRecordScreenState extends State<DetailRecordScreen> {
                           );
 
                           if (!mounted) return;
-                          
+
                           // 기록 저장 후 가족들의 사진 업로드 상태 확인
                           await _checkFamilyPhotoStatusAndShowPopup();
                         } catch (e) {
                           ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(content: Text('업로드 실패: $e')),
+                            SnackBar(
+                              content: Text(
+                                '업로드 실패: $e',
+                                style: const TextStyle(
+                                  color: AppColors.ongiOrange,
+                                ),
+                              ),
+                              backgroundColor: Colors.white,
+                              behavior: SnackBarBehavior.floating,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(20),
+                              ),
+                              duration: const Duration(seconds: 2),
+                            ),
                           );
                         }
                       },
-                      child: const Text('기록하기'),
+                      child: const Text(
+                        '기록하기',
+                        style: TextStyle(
+                          fontSize: 32,
+                          fontWeight: FontWeight.w400,
+                        ),
+                      ),
                     ),
                   ),
                 ),

--- a/frontend/ongi/lib/screens/photo/photo_remind_popup.dart
+++ b/frontend/ongi/lib/screens/photo/photo_remind_popup.dart
@@ -1,159 +1,196 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:ongi/core/app_orange_background.dart';
 import 'package:ongi/core/app_colors.dart';
-import 'package:flutter_svg/svg.dart';
-import 'package:ongi/screens/home/home_screen.dart';
+import 'package:ongi/screens/bottom_nav.dart';
 
 class PhotoRemindPopup extends StatelessWidget {
   const PhotoRemindPopup({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      body: AppOrangeBackground(
-        child: Stack(
-          children: [
-            Positioned(
-              top: 80,
-              right: 30,
-              child: IconButton(
-                icon: SvgPicture.asset(
-                  'assets/images/close_icon_white.svg',
-                  width: 28,
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: const SystemUiOverlayStyle(
+        statusBarColor: Colors.transparent,
+        systemNavigationBarColor: Colors.transparent,
+        statusBarIconBrightness: Brightness.light,
+        systemNavigationBarIconBrightness: Brightness.light,
+      ),
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        body: MediaQuery.removePadding(
+          context: context,
+          removeTop: true,
+          removeBottom: true,
+          child: AppOrangeBackground(
+            child: Stack(
+              children: [
+                Positioned(
+                  top: 80,
+                  right: 30,
+                  child: IconButton(
+                    icon: SvgPicture.asset(
+                      'assets/images/close_icon_white.svg',
+                      width: 28,
+                    ),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        Navigator.of(context).pushAndRemoveUntil(
+                          MaterialPageRoute(
+                            builder: (_) =>
+                                const BottomNavScreen(initialIndex: 0),
+                          ),
+                          (route) => route.isFirst,
+                        );
+                      });
+                    },
+                    iconSize: 36,
+                  ),
                 ),
-                onPressed: () {
-                  Navigator.of(context).pop();
-                },
-                iconSize: 36,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.only(left: 30, top: 160, right: 30),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Text(
-                    '가족들이',
-                    style: TextStyle(
-                      fontSize: 60,
-                      fontWeight: FontWeight.w200,
-                      height: 1.2,
-                      color: Colors.white,
-                    ),
-                  ),
-                  const Text(
-                    '사진을\n올리지\n않았어요!',
-                    style: TextStyle(
-                      fontSize: 60,
-                      fontWeight: FontWeight.w800,
-                      height: 1.2,
-                      color: Colors.white,
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(
-                      left: 10,
-                      top: 170,
-                      right: 10,
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const Text(
-                          '가족들에게 푸시 알림을 전송할까요?',
-                          style: TextStyle(
-                            fontSize: 10,
-                            fontWeight: FontWeight.w300,
-                            color: Colors.white,
-                          ),
+                Padding(
+                  padding: const EdgeInsets.only(left: 30, top: 160, right: 30),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        '가족들이',
+                        style: TextStyle(
+                          fontSize: 60,
+                          fontWeight: FontWeight.w200,
+                          height: 1.2,
+                          color: Colors.white,
                         ),
-                        const SizedBox(height: 12),
-                        ElevatedButton(
-                          style: ElevatedButton.styleFrom(
-                            padding: const EdgeInsets.symmetric(vertical: 8),
-                            minimumSize: const Size(double.infinity, 35),
-                            backgroundColor: Colors.white,
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(20),
-                            ),
-                          ),
-                          onPressed: () async {
-                            try {
-                              Navigator.of(context).pop();
-
-                              // TODO: 실제 API 호출로 대체
-                              await Future.delayed(
-                                const Duration(milliseconds: 500),
-                              );
-
-                              if (Navigator.of(context).mounted) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                    content: const Text(
-                                      '가족들에게 알림을 보냈습니다!',
-                                      style: TextStyle(
-                                        fontSize: 16,
-                                        fontWeight: FontWeight.w500,
-                                        color: AppColors.ongiOrange,
-                                      ),
-                                    ),
-                                    backgroundColor: Colors.white,
-                                    behavior: SnackBarBehavior.floating,
-                                    shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(20),
-                                    ),
-                                    duration: const Duration(seconds: 2),
-                                  ),
-                                );
-
-                                // 약간의 딜레이 후 홈화면으로 이동
-                                await Future.delayed(
-                                  const Duration(milliseconds: 100),
-                                );
-
-                                Navigator.of(context).push(
-                                  MaterialPageRoute(
-                                    builder: (context) => const HomeScreen(),
-                                  ),
-                                );
-                              }
-                            } catch (e) {
-                              // 에러 발생 시 에러 메시지 표시
-                              if (Navigator.of(context).mounted) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
-                                    content: Text(
-                                      '알림 전송에 실패했습니다. 다시 시도해주세요.',
-                                      style: TextStyle(
-                                        fontSize: 16,
-                                        fontWeight: FontWeight.w500,
-                                      ),
-                                    ),
-                                    backgroundColor: Colors.red,
-                                    duration: Duration(seconds: 3),
-                                    behavior: SnackBarBehavior.floating,
-                                  ),
-                                );
-                              }
-                            }
-                          },
-                          child: const Text(
-                            '재촉하기!',
-                            style: TextStyle(
-                              fontSize: 33,
-                              fontWeight: FontWeight.w400,
-                              color: AppColors.ongiOrange,
-                            ),
-                          ),
+                      ),
+                      const Text(
+                        '사진을\n올리지\n않았어요!',
+                        style: TextStyle(
+                          fontSize: 60,
+                          fontWeight: FontWeight.w800,
+                          height: 1.2,
+                          color: Colors.white,
                         ),
-                      ],
-                    ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          left: 10,
+                          top: 170,
+                          right: 10,
+                        ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Text(
+                              '가족들에게 푸시 알림을 전송할까요?',
+                              style: TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.w300,
+                                color: Colors.white,
+                              ),
+                            ),
+                            const SizedBox(height: 12),
+                            ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                padding: const EdgeInsets.symmetric(
+                                  vertical: 8,
+                                ),
+                                minimumSize: const Size(double.infinity, 35),
+                                backgroundColor: Colors.white,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(20),
+                                ),
+                              ),
+                              onPressed: () async {
+                                try {
+                                  Navigator.of(context).pop();
+
+                                  // TODO: 실제 API 호출로 대체
+                                  await Future.delayed(
+                                    const Duration(milliseconds: 500),
+                                  );
+
+                                  if (context.mounted) {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(
+                                        content: Text(
+                                          '가족들에게 알림을 보냈습니다!',
+                                          style: const TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w500,
+                                            color: AppColors.ongiOrange,
+                                          ),
+                                        ),
+                                        backgroundColor: Colors.white,
+                                        behavior: SnackBarBehavior.floating,
+                                        shape: RoundedRectangleBorder(
+                                          borderRadius: BorderRadius.circular(
+                                            20,
+                                          ),
+                                        ),
+                                        duration: const Duration(seconds: 2),
+                                      ),
+                                    );
+
+                                    await Future.delayed(
+                                      const Duration(milliseconds: 100),
+                                    );
+
+                                    if (context.mounted) {
+                                      Navigator.of(context).pop();
+                                      WidgetsBinding.instance
+                                          .addPostFrameCallback((_) {
+                                            Navigator.of(
+                                              context,
+                                            ).pushAndRemoveUntil(
+                                              MaterialPageRoute(
+                                                builder: (_) =>
+                                                    const BottomNavScreen(
+                                                      initialIndex: 0,
+                                                    ),
+                                              ),
+                                              (route) => route.isFirst,
+                                            );
+                                          });
+                                    }
+                                  }
+                                } catch (e) {
+                                  if (context.mounted) {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      const SnackBar(
+                                        content: Text(
+                                          '알림 전송에 실패했습니다. 다시 시도해주세요.',
+                                          style: TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w500,
+                                          ),
+                                        ),
+                                        backgroundColor: Colors.red,
+                                        duration: Duration(seconds: 3),
+                                        behavior: SnackBarBehavior.floating,
+                                      ),
+                                    );
+                                  }
+                                }
+                              },
+                              child: const Text(
+                                '재촉하기!',
+                                style: TextStyle(
+                                  fontSize: 33,
+                                  fontWeight: FontWeight.w400,
+                                  color: AppColors.ongiOrange,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/frontend/ongi/lib/screens/photo/photo_update_popup.dart
+++ b/frontend/ongi/lib/screens/photo/photo_update_popup.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ongi/core/app_orange_background.dart';
 import 'package:ongi/core/app_colors.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:ongi/screens/bottom_nav.dart';
 
 class PhotoUpdatePopup extends StatelessWidget {
@@ -9,94 +10,111 @@ class PhotoUpdatePopup extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      body: AppOrangeBackground(
-        child: Stack(
-          children: [
-            Positioned(
-              top: 80,
-              right: 30,
-              child: IconButton(
-                icon: SvgPicture.asset(
-                  'assets/images/close_icon_white.svg',
-                  width: 28,
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: const SystemUiOverlayStyle(
+        statusBarColor: Colors.transparent,
+        systemNavigationBarColor: Colors.transparent,
+        statusBarIconBrightness: Brightness.light,
+        systemNavigationBarIconBrightness: Brightness.light,
+      ),
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        body: MediaQuery.removePadding(
+          context: context,
+          removeTop: true,
+          removeBottom: true,
+          child: AppOrangeBackground(
+            child: Stack(
+              children: [
+                Positioned(
+                  top: 80,
+                  right: 30,
+                  child: IconButton(
+                    icon: SvgPicture.asset(
+                      'assets/images/close_icon_white.svg',
+                      width: 28,
+                    ),
+                    iconSize: 36,
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        Navigator.of(context).pushAndRemoveUntil(
+                          MaterialPageRoute(
+                            builder: (_) =>
+                                const BottomNavScreen(initialIndex: 0),
+                          ),
+                          (route) => route.isFirst,
+                        );
+                      });
+                    },
+                  ),
                 ),
-                onPressed: () {
-                  Navigator.of(context).pop();
-                },
-                iconSize: 36,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.only(left: 30, top: 160, right: 30),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Text(
-                    '가족들도',
-                    style: TextStyle(
-                      fontSize: 60,
-                      fontWeight: FontWeight.w200,
-                      height: 1.2,
-                      color: Colors.white,
-                    ),
-                  ),
-                  const Text(
-                    '사진을\n올렸어요!',
-                    style: TextStyle(
-                      fontSize: 60,
-                      fontWeight: FontWeight.w800,
-                      height: 1.2,
-                      color: Colors.white,
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(
-                      left: 10,
-                      top: 180,
-                      right: 10,
-                    ),
-                    child: ElevatedButton(
-                      style: ElevatedButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(vertical: 8),
-                        minimumSize: const Size(double.infinity, 35),
-                        backgroundColor: Colors.white,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                      ),
-                      onPressed: () async {
-                        // 팝업 닫기
-                        Navigator.of(context).pop();
-                        
-                        await Future.delayed(const Duration(milliseconds: 100));
-                        
-                        if (Navigator.of(context).mounted) {
-                          // 앨범 탭이 선택된 상태로 BottomNavScreen으로 이동
-                          Navigator.of(context).pushAndRemoveUntil(
-                            MaterialPageRoute(
-                              builder: (context) => const BottomNavScreen(initialIndex: 2),
-                            ),
-                            (route) => false, // 모든 이전 화면 제거
-                          );
-                        }
-                      },
-
-                      child: const Text(
-                        '보러가기!',
+                Padding(
+                  padding: const EdgeInsets.only(left: 30, top: 160, right: 30),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        '가족들도',
                         style: TextStyle(
-                          fontSize: 33,
-                          fontWeight: FontWeight.w400,
-                          color: AppColors.ongiOrange,
+                          fontSize: 60,
+                          fontWeight: FontWeight.w200,
+                          height: 1.2,
+                          color: Colors.white,
                         ),
                       ),
-                    ),
+                      const Text(
+                        '사진을\n올렸어요!',
+                        style: TextStyle(
+                          fontSize: 60,
+                          fontWeight: FontWeight.w800,
+                          height: 1.2,
+                          color: Colors.white,
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          left: 10,
+                          top: 180,
+                          right: 10,
+                        ),
+                        child: ElevatedButton(
+                          style: ElevatedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(vertical: 8),
+                            minimumSize: const Size(double.infinity, 35),
+                            backgroundColor: Colors.white,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(20),
+                            ),
+                          ),
+                          onPressed: () {
+                            Navigator.of(context).pop();
+                            WidgetsBinding.instance.addPostFrameCallback((_) {
+                              Navigator.of(context).pushAndRemoveUntil(
+                                MaterialPageRoute(
+                                  builder: (_) =>
+                                      const BottomNavScreen(initialIndex: 2),
+                                ),
+                                (route) => route.isFirst,
+                              );
+                            });
+                          },
+                          child: const Text(
+                            '보러가기!',
+                            style: TextStyle(
+                              fontSize: 33,
+                              fontWeight: FontWeight.w400,
+                              color: AppColors.ongiOrange,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
1. 마음 기록 하루 한 번 기록 제한 구현
2. 팝업 화면 크기 수정
3. 마음 기록 입력 화면 위치 수정
4. 기본 스플래시 화면 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 하루 1회 기록 제한 안내: 오늘 이미 기록했다면 스낵바로 알림, 아니면 기록 화면으로 이동.
  - 상세 기록 업로드 시 위치/코멘트/감정 정보 포함 전송.
- UI/UX
  - 리마인드/업데이트 팝업 전체 화면화, 상태바 스타일 개선, 버튼/타이포그래피 정돈, 스낵바 스타일 개선.
  - 주소 표기 로직 개선으로 더 자연스러운 위치 표시.
  - 체크 화면의 뒤로가기/닫기 동작이 하단 탭 화면으로 일관되게 이동.
  - 앱 실행 시 스플래시(런치) 배경 변경 가능.
- 기타
  - 불필요한 리소스/임포트 정리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->