### PR TITLE
feat: 유저 fcm 토큰 업로드 기능 추가

### DIFF
--- a/backend/ongi/src/main/java/ongi/user/controller/UserController.java
+++ b/backend/ongi/src/main/java/ongi/user/controller/UserController.java
@@ -1,13 +1,18 @@
 package ongi.user.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import ongi.security.CustomUserDetails;
+import ongi.user.dto.FcmTokenUpdateRequestDto;
 import ongi.user.dto.UserExistsResponse;
 import ongi.user.dto.UserInfo;
 import ongi.user.service.UserService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,5 +34,13 @@ public class UserController {
     public ResponseEntity<UserExistsResponse> getUserExists(String email) {
         boolean userExists = userService.getUserExists(email);
         return ResponseEntity.ok(new UserExistsResponse(userExists));
+    }
+
+    @PostMapping("fcm-token")
+    public ResponseEntity<Void> updateUserFcmToken(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody FcmTokenUpdateRequestDto request) {
+        userService.updateFcmToken(userDetails.getUser(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/backend/ongi/src/main/java/ongi/user/dto/FcmTokenUpdateRequestDto.java
+++ b/backend/ongi/src/main/java/ongi/user/dto/FcmTokenUpdateRequestDto.java
@@ -1,0 +1,10 @@
+package ongi.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record FcmTokenUpdateRequestDto(
+        @NotNull @NotBlank String fcmToken
+) {
+
+}

--- a/backend/ongi/src/main/java/ongi/user/entity/UserFcmToken.java
+++ b/backend/ongi/src/main/java/ongi/user/entity/UserFcmToken.java
@@ -1,0 +1,34 @@
+package ongi.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ongi.common.entity.BaseEntity;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class UserFcmToken extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    @OneToOne(optional = false, fetch = FetchType.LAZY)
+    User user;
+
+    @Column(nullable = false, updatable = false)
+    String token;
+}

--- a/backend/ongi/src/main/java/ongi/user/service/UserFcmTokenRepository.java
+++ b/backend/ongi/src/main/java/ongi/user/service/UserFcmTokenRepository.java
@@ -1,0 +1,11 @@
+package ongi.user.service;
+
+import java.util.Optional;
+import ongi.user.entity.User;
+import ongi.user.entity.UserFcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface UserFcmTokenRepository extends JpaRepository<UserFcmToken, Long> {
+
+    Optional<UserFcmToken> findByUser(User user);
+}

--- a/backend/ongi/src/main/java/ongi/user/service/UserService.java
+++ b/backend/ongi/src/main/java/ongi/user/service/UserService.java
@@ -1,6 +1,9 @@
 package ongi.user.service;
 
 import lombok.RequiredArgsConstructor;
+import ongi.user.dto.FcmTokenUpdateRequestDto;
+import ongi.user.entity.User;
+import ongi.user.entity.UserFcmToken;
 import ongi.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,8 +14,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final UserFcmTokenRepository userFcmTokenRepository;
 
     public boolean getUserExists(String email) {
         return userRepository.existsByEmail(email);
+    }
+
+    @Transactional
+    public void updateFcmToken(User user, FcmTokenUpdateRequestDto requestDto) {
+        UserFcmToken userFcmToken = userFcmTokenRepository.findByUser(user).orElse(
+                UserFcmToken.builder().user(user).token(requestDto.fcmToken()).build());
+
+        userFcmTokenRepository.save(userFcmToken);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 로그인한 사용자의 FCM 토큰을 등록/갱신하는 엔드포인트가 추가되었습니다(POST /users/fcm-token).
  - 요청 본문에 대한 유효성 검증을 수행하며, 성공 시 201 Created를 반환합니다.
  - 사용자별 토큰이 안전하게 저장되어 푸시 알림 수신 설정이 원활해집니다.
  - 인증된 요청에서만 이용 가능하며, 기존 기능에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->