### PR TITLE
feat: 마음 기록 조회 시 사용자 이름 같이 나오도록 수정

### DIFF
--- a/backend/ongi/src/main/java/ongi/maum_log/dto/MaumLogDto.java
+++ b/backend/ongi/src/main/java/ongi/maum_log/dto/MaumLogDto.java
@@ -12,7 +12,8 @@ public record MaumLogDto(
         String comment,
         String location,
         List<Emotion> emotions,
-        UUID uploader
+        UUID uploader,
+        String uploaderName
 ) {
     public static MaumLogDto of(URL frontPresignedUrl, URL backPresignedUrl, MaumLog maumLog) {
         return new MaumLogDto(
@@ -21,7 +22,8 @@ public record MaumLogDto(
                 maumLog.getComment(),
                 maumLog.getLocation(),
                 maumLog.getEmotions(),
-                maumLog.getCreatedBy().getUuid()
+                maumLog.getCreatedBy().getUuid(),
+                maumLog.getCreatedBy().getName()
         );
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 마음로그 항목에 업로더 이름 정보가 추가되어, 목록/상세 화면에서 작성자의 이름을 함께 확인할 수 있습니다.
  - 공유·협업 시 작성자 식별이 더 쉬워졌으며, 사용자 경험이 향상되었습니다.
- 문서
  - 사용자에게 노출되는 마음로그 데이터 항목에 업로더 이름이 포함됨을 반영하여 설명을 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->