### PR TITLE
fix: 약 조회 시 이미지 null 여부 체크 추가

### DIFF
--- a/backend/ongi/src/main/java/ongi/pill/service/PillService.java
+++ b/backend/ongi/src/main/java/ongi/pill/service/PillService.java
@@ -156,7 +156,8 @@ public class PillService {
                 .collect(Collectors.groupingBy(record -> record.getPill().getId()));
 
         return pills.stream()
-                .map(pill -> new PillInfoWithIntakeStatus(pill, s3FileService.createSignedGetUrl(DIR_NAME, pill.getFileName()),
+                .map(pill -> new PillInfoWithIntakeStatus(pill,
+                        pill.getFileName() != null ? s3FileService.createSignedGetUrl(DIR_NAME, pill.getFileName()) : null,
                         intakeRecordsMap.getOrDefault(pill.getId(), List.of())))
                 .toList();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 이미지 파일이 없는 일부 알약에서 발생하던 예기치 않은 오류를 방지하여 앱 크래시와 오류 메시지 노출을 줄였습니다.
  * 이미지가 없는 알약도 목록에서 정상적으로 표시되며, 해당 경우에는 이미지 없이 노출됩니다.
  * 가족 약 목록 조회의 안정성이 개선되어 간헐적 실패가 감소하고 전반적인 신뢰성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->