### PR TITLE
feat: 7일간 가족 걸음 수 랭킹 API 구현

### DIFF
--- a/backend/ongi/src/main/java/ongi/step/controller/StepController.java
+++ b/backend/ongi/src/main/java/ongi/step/controller/StepController.java
@@ -2,8 +2,10 @@ package ongi.step.controller;
 
 import jakarta.annotation.Nullable;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import ongi.security.CustomUserDetails;
+import ongi.step.dto.FamilyStepRankResponse;
 import ongi.step.dto.FamilyStepResponse;
 import ongi.step.dto.StepUpsertRequest;
 import ongi.step.service.StepService;
@@ -37,5 +39,12 @@ public class StepController {
         }
         FamilyStepResponse response = stepService.getFamilySteps(userDetails.getUser(), date);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/rank")
+    public ResponseEntity<List<FamilyStepRankResponse>> getFamilyStepsRank(
+            @AuthenticationPrincipal CustomUserDetails userDetails){
+        List<FamilyStepRankResponse> responses = stepService.getFamilyStepRank(userDetails.getUser(), LocalDate.now());
+        return ResponseEntity.ok(responses);
     }
 } 

--- a/backend/ongi/src/main/java/ongi/step/dto/FamilyStepRankResponse.java
+++ b/backend/ongi/src/main/java/ongi/step/dto/FamilyStepRankResponse.java
@@ -1,0 +1,9 @@
+package ongi.step.dto;
+
+public record FamilyStepRankResponse(
+        String familyName,
+        Integer averageSteps,
+        Boolean isOurFamily
+) {
+
+}

--- a/backend/ongi/src/main/java/ongi/step/dto/FamilyStepRankingResponse.java
+++ b/backend/ongi/src/main/java/ongi/step/dto/FamilyStepRankingResponse.java
@@ -1,5 +1,0 @@
-package ongi.step.dto;
-
-public class FamilyStepRankingResponse {
-
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 가족 걸음 수 랭킹 조회를 추가했습니다. 금주(월요일부터 오늘까지) 누적 걸음 수를 가족 구성원 수로 나눈 평균 기준으로 순위를 제공합니다.
  - 사용자가 속한 가족을 목록에서 구분 표시합니다.
  - 결과는 평균 걸음 수 기준 내림차순으로 정렬되어 반환됩니다.
  - 기존의 가족별 걸음 수 조회 기능은 변경 없이 그대로 사용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->