### PR TITLE
fix: time grid 칸 누를 때마다 위로 올라가는 문제 해결

### DIFF
--- a/frontend/ongi/lib/screens/health/exercise_record_detail_screen.dart
+++ b/frontend/ongi/lib/screens/health/exercise_record_detail_screen.dart
@@ -390,9 +390,6 @@ class _ExerciseRecordDetailScreenState
                           bottom: 20,
                           child: Center(
                             child: TimeGrid(
-                              key: ValueKey(
-                                "${selectedDate.year}-${selectedDate.month}-${selectedDate.day}-${selected.length}-${selected.hashCode}",
-                              ),
                               initialSelected: selected,
                               cellColor: Colors.white,
                               cellSelectedColor: AppColors.ongiOrange,

--- a/frontend/ongi/lib/widgets/time_grid.dart
+++ b/frontend/ongi/lib/widgets/time_grid.dart
@@ -25,11 +25,19 @@ class TimeGrid extends StatefulWidget {
 class _TimeGridState extends State<TimeGrid> {
   late Set<int> _selected;
   static const int _startHour = 6;
+  late ScrollController _scrollController;
 
   @override
   void initState() {
     super.initState();
     _selected = widget.initialSelected.toSet();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
   }
 
   @override
@@ -52,6 +60,7 @@ class _TimeGridState extends State<TimeGrid> {
     final hours = List<int>.generate(24, (i) => (_startHour + i) % 24);
 
     return SingleChildScrollView(
+      controller: _scrollController,
       child: Column(
         children: [
           for (var hour in hours)
@@ -75,12 +84,25 @@ class _TimeGridState extends State<TimeGrid> {
                   GestureDetector(
                     onTap: widget.onValueChanged != null ? () {
                       final idx = hour * 6 + seg;
+                      final currentScrollOffset = _scrollController.hasClients 
+                          ? _scrollController.offset 
+                          : 0.0;
+                      
                       setState(() {
-                        if (_selected.contains(idx))
+                        if (_selected.contains(idx)) {
                           _selected.remove(idx);
-                        else
+                        } else {
                           _selected.add(idx);
-                        widget.onValueChanged?.call(_selected.toList()..sort());
+                        }
+                      });
+                      
+                      widget.onValueChanged?.call(_selected.toList()..sort());
+                      
+                      // 스크롤 위치 복원
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        if (_scrollController.hasClients) {
+                          _scrollController.jumpTo(currentScrollOffset);
+                        }
                       });
                     } : null,
                     child: Container(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 운동 기록 상세 화면의 시간 그리드에서 시간 선택 시 스크롤 위치가 초기화되거나 튀는 현상을 방지했습니다. 선택 이후에도 기존 스크롤 위치를 유지하여 연속 선택 시 화면 흔들림이 줄어듭니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->