### PR TITLE
fix: 온도 히스토리 텍스트 형식 수정

### DIFF
--- a/frontend/ongi/lib/screens/home/home_degree_graph.dart
+++ b/frontend/ongi/lib/screens/home/home_degree_graph.dart
@@ -249,7 +249,8 @@ class _HomeDegreeGraph extends State<HomeDegreeGraph> {
 
                       // 경계값에서 약간 안쪽으로만 필터링
                       final smallMargin = horizontalInterval * 0.1;
-                      if ((value - minY).abs() < smallMargin || (value - maxY).abs() < smallMargin) {
+                      if ((value - minY).abs() < smallMargin ||
+                          (value - maxY).abs() < smallMargin) {
                         return const SizedBox.shrink();
                       }
 
@@ -373,7 +374,7 @@ class _HomeDegreeGraph extends State<HomeDegreeGraph> {
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
-                      "${item.userName}이 ${item.formattedChange} 상승 시켰어요!",
+                      "${item.userName}${item.userName == '우리 가족' ? '이' : ' 님이'} ${item.formattedChange} ${item.contributed >= 0 ? '상승' : '하강'}시켰어요!",
                       style: const TextStyle(
                         color: Colors.grey,
                         fontSize: 15,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 홈 화면 히스토리 항목 문구가 상황에 맞게 동적으로 표시됩니다:
    - 사용자명이 ‘우리 가족’이면 ‘이’, 그 외에는 ‘ 님이’를 사용
    - 변화값이 0 이상이면 ‘상승’, 미만이면 ‘하강’으로 표기
    - 변화량 표기는 기존과 동일

- Style
  - 표시 기능에 영향 없는 내부 포맷 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->