### PR TITLE
fix: 괄호 수정

### DIFF
--- a/frontend/ongi/lib/screens/health/health_status_input_screen.dart
+++ b/frontend/ongi/lib/screens/health/health_status_input_screen.dart
@@ -1058,7 +1058,6 @@ class _HealthStatusInputScreenState extends State<HealthStatusInputScreen> {
   Widget _buildStretchingButton() {
     return Visibility(
       visible: _isStretchingVisible, // _isStretchingVisible 값에 따라 버튼 표시 여부 결정
-     ),
       child: Padding(
         padding: const EdgeInsets.all(25),
         child: Column(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 건강 상태 입력 화면에서 스트레칭 버튼의 가시성 처리 중 위젯 트리 구성 오류로 child 위젯이 누락되어 버튼이 보이지 않거나 레이아웃이 깨질 수 있던 문제를 수정했습니다. 이제 _isStretchingVisible 값에 따라 패딩이 포함된 버튼이 일관되게 렌더링되며, 예기치 않은 공백이나 표시 오류가 발생하지 않습니다. 기능 동작 자체의 변경은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->