### PR TITLE
feat: 리워드 화면 사용 가능 온도 설명 텍스트 추가 및 카메라 화면 설명 텍스트 굵기 변경

### DIFF
--- a/frontend/ongi/lib/screens/add_record_screen.dart
+++ b/frontend/ongi/lib/screens/add_record_screen.dart
@@ -306,7 +306,7 @@ class AddRecordScreenState extends State<AddRecordScreen>
                       style: TextStyle(
                         fontSize: 12,
                         color: Colors.black45,
-                        fontWeight: FontWeight.w400,
+                        fontWeight: FontWeight.w500,
                       ),
                     ),
                   ),

--- a/frontend/ongi/lib/screens/reward_screen.dart
+++ b/frontend/ongi/lib/screens/reward_screen.dart
@@ -210,7 +210,7 @@ class _RewardScreenState extends State<RewardScreen> {
                                         depth: -5, // +면 돌출, -면 들어간 효과
                                         intensity: 0.3,
                                         shadowDarkColorEmboss: Colors.black54
-                                            .withOpacity(0.9),
+                                            .withValues(alpha: 0.9),
                                         shape: NeumorphicShape.concave,
                                         boxShape: NeumorphicBoxShape.roundRect(
                                           BorderRadius.circular(20),
@@ -222,7 +222,7 @@ class _RewardScreenState extends State<RewardScreen> {
                                       ),
                                       child: SizedBox(
                                         width: double.infinity,
-                                        height: 90,
+                                        height: 100,
                                         child: Row(
                                           crossAxisAlignment:
                                               CrossAxisAlignment.start,
@@ -279,6 +279,20 @@ class _RewardScreenState extends State<RewardScreen> {
                                                         height: 1.0,
                                                         color: AppColors
                                                             .ongiOrange,
+                                                      ),
+                                                    ),
+                                                  ),
+                                                  Align(
+                                                    alignment:
+                                                        Alignment.bottomRight,
+                                                    child: Text(
+                                                      '기본 온도 36.5℃를 제외한 실제 사용 가능 온도예요!',
+                                                      style: const TextStyle(
+                                                        fontSize: 9,
+                                                        fontWeight:
+                                                            FontWeight.w400,
+                                                        height: 1.0,
+                                                        color: Colors.black54,
                                                       ),
                                                     ),
                                                   ),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> UI text updates in `add_record_screen.dart` and `reward_screen.dart` for improved clarity and styling.
> 
>   - **Add Record Screen**:
>     - Change font weight of description text from `w400` to `w500` in `AddRecordScreenState`.
>   - **Reward Screen**:
>     - Add new description text about usable temperature in `_RewardScreenState`.
>     - Change `withOpacity` to `withValues` for `shadowDarkColorEmboss` in `NeumorphicStyle`.
>     - Increase height of `SizedBox` from 90 to 100 in `_RewardScreenState`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Neibce%2FOnGi&utm_source=github&utm_medium=referral)<sup> for 618401b1c2897f43bd83c7867f787c953117dd14. You can [customize](https://app.ellipsis.dev/Neibce/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 보상 화면 온도 표시 영역에 안내 문구 추가: “기본 온도 36.5℃를 제외한 실제 사용 가능 온도예요!”(우하단 정렬의 소형 캡션)
- 스타일
  - 추가/기록 화면의 작은 텍스트 가독성 향상을 위해 글자 두께 상향
  - 보상 화면 온도 카드 높이를 90→100으로 조정해 레이아웃 균형 개선
  - 반투명 색상 표현을 정밀화해 대비 및 시인성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->